### PR TITLE
se añade config en el plugin maven-shade-plugin para que solo incluya…

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/mavenDependency" vcs="Git" />
   </component>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,16 @@
           <artifactId>maven-shade-plugin</artifactId>
           <version>3.2.2</version>
           <configuration>
-            <minimizeJar>true</minimizeJar>
+            <filters>
+            <filter>
+              <artifact>junit:junit</artifact>
+              <!--<excludeDefaults>false</excludeDefaults>-->
+              <includes>
+                <include>junit/textui/**</include>
+              </includes>
+            </filter>
+          </filters>
+            <!--<minimizeJar>true</minimizeJar>-->
             <transformers>
               <transformer
                       implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
@@ -120,7 +129,7 @@
 
 
         <!--incluir las dependencias en el jar-->
-        <plugin>
+        <!--<plugin>
           <artifactId>maven-assembly-plugin</artifactId>
           <configuration>
             <archive>
@@ -141,7 +150,7 @@
               </goals>
             </execution>
           </executions>
-        </plugin>
+        </plugin>-->
 
     </plugins>
     </pluginManagement>


### PR DESCRIPTION
… de la dependencia de junit, solo las clases que estan dentro del paquete junit/textui y todas las demas clases que pertenecen a esa dependencia no se incluyen, salvo si se usa la property, <excludeDefaults>false</excludeDefaults> que se ha incluido comentada.